### PR TITLE
Vhdl aes 256 core implementation and testbench

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+## AES-256 VHDL Core (ISE 14.7 Compatible)
+
+Project structure:
+
+- `src/aes_pkg.vhd`: Types, S-Box, Inv S-Box, Rcon, GF(2^8) helpers
+- `src/add_round_key.vhd`: AddRoundKey
+- `src/subbytes.vhd`, `src/inv_subbytes.vhd`
+- `src/shiftrows.vhd`, `src/inv_shiftrows.vhd`
+- `src/mixcolumns.vhd`, `src/inv_mixcolumns.vhd`
+- `src/key_expand_aes256.vhd`: AES-256 key schedule -> 15 round keys
+- `src/aes_round_enc.vhd`, `src/aes_round_dec.vhd`: round primitives
+- `src/aes256_core.vhd`: Iterative top-level core with FSM
+- `tb/tb_aes256_core.vhd`: Testbench with NIST AES-256 vectors
+
+### Build & Simulate (Xilinx ISE 14.7)
+
+1. Create a new ISE project, set family to Virtex-5 (e.g. ML501: XC5VLX50T), VHDL.
+2. Add all VHDL files from `src/` to the project, mark `tb/tb_aes256_core.vhd` as top for simulation.
+3. Ensure `aes_pkg.vhd` is compiled before other design files.
+4. Run behavioral simulation. The testbench prints "All tests passed" when successful.
+
+### Interface
+
+Top-level `aes256_core` ports:
+
+- `clk`, `rst`: clock and synchronous reset
+- `start`: pulse high to begin operation
+- `enc_n`: '1' encrypt, '0' decrypt
+- `key`: 256-bit key
+- `data_in`: 128-bit plaintext or ciphertext
+- `data_out`: 128-bit result after `ready`
+- `ready`: high for one cycle when output is valid
+

--- a/src/add_round_key.vhd
+++ b/src/add_round_key.vhd
@@ -1,0 +1,16 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity add_round_key is
+  port (
+    state_in  : in  std_logic_vector(127 downto 0);
+    round_key : in  std_logic_vector(127 downto 0);
+    state_out : out std_logic_vector(127 downto 0)
+  );
+end entity add_round_key;
+
+architecture rtl of add_round_key is
+begin
+  state_out <= state_in xor round_key;
+end architecture rtl;
+

--- a/src/aes256_core.vhd
+++ b/src/aes256_core.vhd
@@ -1,0 +1,185 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+-- Iterative AES-256 core with simple handshaking.
+-- Encrypt or decrypt 128-bit block using 256-bit key.
+entity aes256_core is
+  port (
+    clk       : in  std_logic;
+    rst       : in  std_logic;
+    start     : in  std_logic;
+    enc_n     : in  std_logic; -- '1' for encrypt, '0' for decrypt
+    key       : in  std_logic_vector(255 downto 0);
+    data_in   : in  std_logic_vector(127 downto 0);
+    data_out  : out std_logic_vector(127 downto 0);
+    ready     : out std_logic
+  );
+end entity aes256_core;
+
+architecture rtl of aes256_core is
+  component key_expand_aes256 is
+    port ( key_in : in std_logic_vector(255 downto 0); round_keys_flat : out std_logic_vector((15*128)-1 downto 0) );
+  end component;
+  component aes_round_enc is
+    generic ( IS_FINAL : boolean := false );
+    port ( state_in : in std_logic_vector(127 downto 0); round_key : in std_logic_vector(127 downto 0); state_out : out std_logic_vector(127 downto 0) );
+  end component;
+  component aes_round_dec is
+    generic ( IS_FINAL : boolean := false );
+    port ( state_in : in std_logic_vector(127 downto 0); round_key : in std_logic_vector(127 downto 0); state_out : out std_logic_vector(127 downto 0) );
+  end component;
+  component add_round_key is
+    port ( state_in : in std_logic_vector(127 downto 0); round_key : in std_logic_vector(127 downto 0); state_out : out std_logic_vector(127 downto 0) );
+  end component;
+
+  type state_t is (IDLE, EXPAND, INIT_ADDKEY, ROUND, FINAL, DONE);
+  signal cs, ns : state_t;
+
+  signal rk_flat : std_logic_vector((15*128)-1 downto 0);
+  type rk_array_t is array (0 to 14) of std_logic_vector(127 downto 0);
+  signal rks : rk_array_t;
+
+  signal round_idx  : integer range 0 to 14;
+  signal state_reg  : std_logic_vector(127 downto 0);
+  signal ark_init   : std_logic_vector(127 downto 0);
+  signal round_out_nf_enc : std_logic_vector(127 downto 0);
+  signal round_out_f_enc  : std_logic_vector(127 downto 0);
+  signal round_out_nf_dec : std_logic_vector(127 downto 0);
+  signal round_out_f_dec  : std_logic_vector(127 downto 0);
+  signal rk_nf     : std_logic_vector(127 downto 0);
+  signal rk_final  : std_logic_vector(127 downto 0);
+
+begin
+  -- key expansion
+  u_kexp: key_expand_aes256 port map(key_in => key, round_keys_flat => rk_flat);
+
+  -- unpack keys: rk[0]..rk[14]
+  gen_rk: for i in 0 to 14 generate
+  begin
+    rks(i) <= rk_flat(((15-1-i)*128)+127 downto ((15-1-i)*128));
+  end generate;
+
+  -- initial add round key depends on enc/dec
+  ark_init <= data_in xor (rks(0)) when enc_n = '1' else data_in xor (rks(14));
+
+  -- encryption and decryption rounds (combinational), selected in FSM
+  -- Encryption rounds
+  u_enc_round_nf: aes_round_enc
+    generic map(IS_FINAL => false)
+    port map(state_in => state_reg, round_key => rk_nf, state_out => round_out_nf_enc);
+  u_enc_round_f: aes_round_enc
+    generic map(IS_FINAL => true)
+    port map(state_in => state_reg, round_key => rk_final, state_out => round_out_f_enc);
+
+  -- Decryption rounds
+  u_dec_round_nf: aes_round_dec
+    generic map(IS_FINAL => false)
+    port map(state_in => state_reg, round_key => rk_nf, state_out => round_out_nf_dec);
+  u_dec_round_f: aes_round_dec
+    generic map(IS_FINAL => true)
+    port map(state_in => state_reg, round_key => rk_final, state_out => round_out_f_dec);
+
+  process(clk)
+  begin
+    if rising_edge(clk) then
+      if rst = '1' then
+        cs <= IDLE;
+        round_idx <= 0;
+        state_reg <= (others => '0');
+      else
+        cs <= ns;
+        case cs is
+          when INIT_ADDKEY =>
+            state_reg <= ark_init;
+          when ROUND =>
+            if enc_n = '1' then
+              state_reg <= round_out_nf_enc;
+            else
+              state_reg <= round_out_nf_dec;
+            end if;
+          when FINAL =>
+            if enc_n = '1' then
+              state_reg <= round_out_f_enc;
+            else
+              state_reg <= round_out_f_dec;
+            end if;
+          when others => null;
+        end case;
+      end if;
+    end if;
+  end process;
+
+  -- simple next-state logic
+  process(cs, start, enc_n, round_idx)
+  begin
+    ns    <= cs;
+    case cs is
+      when IDLE =>
+        if start = '1' then
+          ns <= EXPAND;  -- expansion combinational, advance immediately
+        end if;
+      when EXPAND =>
+        ns <= INIT_ADDKEY;
+      when INIT_ADDKEY =>
+        ns <= ROUND;
+      when ROUND =>
+        if enc_n = '1' then
+          if round_idx = 13 then
+            ns <= FINAL;
+          else
+            ns <= ROUND;
+          end if;
+        else
+          if round_idx = 1 then
+            ns <= FINAL;
+          else
+            ns <= ROUND;
+          end if;
+        end if;
+      when FINAL =>
+        ns <= DONE;
+      when DONE =>
+        ns <= IDLE;
+      when others => ns <= IDLE;
+    end case;
+  end process;
+
+  -- round index control
+  process(clk)
+  begin
+    if rising_edge(clk) then
+      if rst = '1' then
+        round_idx <= 0;
+      else
+        if cs = INIT_ADDKEY then
+          if enc_n = '1' then
+            round_idx <= 1;     -- enc: start at K1
+          else
+            round_idx <= 13;    -- dec: start at K13
+          end if;
+        elsif cs = ROUND then
+          if enc_n = '1' then
+            if round_idx < 13 then
+              round_idx <= round_idx + 1;
+            end if;
+          else
+            if round_idx > 1 then
+              round_idx <= round_idx - 1;
+            end if;
+          end if;
+        end if;
+      end if;
+    end if;
+  end process;
+
+  -- Select round keys for non-final and final
+  rk_nf    <= rks(round_idx);
+  rk_final <= rks(14) when enc_n = '1' else rks(0);
+
+  -- final output and ready
+  data_out <= state_reg;
+  ready <= '1' when cs = DONE else '0';
+
+end architecture rtl;
+

--- a/src/aes_pkg.vhd
+++ b/src/aes_pkg.vhd
@@ -1,0 +1,164 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+package aes_pkg is
+  subtype byte_t  is std_logic_vector(7 downto 0);
+  subtype word_t  is std_logic_vector(31 downto 0);
+  subtype state128_t is std_logic_vector(127 downto 0);
+
+  type sbox_array_t is array (0 to 255) of byte_t;
+  constant SBOX      : sbox_array_t;  -- deferred constant
+  constant INV_SBOX  : sbox_array_t;  -- deferred constant
+
+  type rcon_array_t is array (1 to 14) of byte_t;
+  constant RCON : rcon_array_t;       -- deferred constant
+
+  -- GF(2^8) helpers
+  function xtime(b : byte_t) return byte_t;
+  function gmul2(b : byte_t) return byte_t;
+  function gmul3(b : byte_t) return byte_t;
+  function gmul9(b : byte_t) return byte_t;
+  function gmul11(b : byte_t) return byte_t;
+  function gmul13(b : byte_t) return byte_t;
+  function gmul14(b : byte_t) return byte_t;
+
+  -- Byte/word transforms
+  function sub_byte(b : byte_t) return byte_t;
+  function inv_sub_byte(b : byte_t) return byte_t;
+  function sub_word(w : word_t) return word_t;
+  function rot_word(w : word_t) return word_t;
+
+end package aes_pkg;
+
+package body aes_pkg is
+
+  -- S-Box (AES Rijndael)
+  constant SBOX : sbox_array_t := (
+    x"63", x"7C", x"77", x"7B", x"F2", x"6B", x"6F", x"C5", x"30", x"01", x"67", x"2B", x"FE", x"D7", x"AB", x"76",
+    x"CA", x"82", x"C9", x"7D", x"FA", x"59", x"47", x"F0", x"AD", x"D4", x"A2", x"AF", x"9C", x"A4", x"72", x"C0",
+    x"B7", x"FD", x"93", x"26", x"36", x"3F", x"F7", x"CC", x"34", x"A5", x"E5", x"F1", x"71", x"D8", x"31", x"15",
+    x"04", x"C7", x"23", x"C3", x"18", x"96", x"05", x"9A", x"07", x"12", x"80", x"E2", x"EB", x"27", x"B2", x"75",
+    x"09", x"83", x"2C", x"1A", x"1B", x"6E", x"5A", x"A0", x"52", x"3B", x"D6", x"B3", x"29", x"E3", x"2F", x"84",
+    x"53", x"D1", x"00", x"ED", x"20", x"FC", x"B1", x"5B", x"6A", x"CB", x"BE", x"39", x"4A", x"4C", x"58", x"CF",
+    x"D0", x"EF", x"AA", x"FB", x"43", x"4D", x"33", x"85", x"45", x"F9", x"02", x"7F", x"50", x"3C", x"9F", x"A8",
+    x"51", x"A3", x"40", x"8F", x"92", x"9D", x"38", x"F5", x"BC", x"B6", x"DA", x"21", x"10", x"FF", x"F3", x"D2",
+    x"CD", x"0C", x"13", x"EC", x"5F", x"97", x"44", x"17", x"C4", x"A7", x"7E", x"3D", x"64", x"5D", x"19", x"73",
+    x"60", x"81", x"4F", x"DC", x"22", x"2A", x"90", x"88", x"46", x"EE", x"B8", x"14", x"DE", x"5E", x"0B", x"DB",
+    x"E0", x"32", x"3A", x"0A", x"49", x"06", x"24", x"5C", x"C2", x"D3", x"AC", x"62", x"91", x"95", x"E4", x"79",
+    x"E7", x"C8", x"37", x"6D", x"8D", x"D5", x"4E", x"A9", x"6C", x"56", x"F4", x"EA", x"65", x"7A", x"AE", x"08",
+    x"BA", x"78", x"25", x"2E", x"1C", x"A6", x"B4", x"C6", x"E8", x"DD", x"74", x"1F", x"4B", x"BD", x"8B", x"8A",
+    x"70", x"3E", x"B5", x"66", x"48", x"03", x"F6", x"0E", x"61", x"35", x"57", x"B9", x"86", x"C1", x"1D", x"9E",
+    x"E1", x"F8", x"98", x"11", x"69", x"D9", x"8E", x"94", x"9B", x"1E", x"87", x"E9", x"CE", x"55", x"28", x"DF",
+    x"8C", x"A1", x"89", x"0D", x"BF", x"E6", x"42", x"68", x"41", x"99", x"2D", x"0F", x"B0", x"54", x"BB", x"16"
+  );
+
+  -- Inverse S-Box
+  constant INV_SBOX : sbox_array_t := (
+    x"52", x"09", x"6A", x"D5", x"30", x"36", x"A5", x"38", x"BF", x"40", x"A3", x"9E", x"81", x"F3", x"D7", x"FB",
+    x"7C", x"E3", x"39", x"82", x"9B", x"2F", x"FF", x"87", x"34", x"8E", x"43", x"44", x"C4", x"DE", x"E9", x"CB",
+    x"54", x"7B", x"94", x"32", x"A6", x"C2", x"23", x"3D", x"EE", x"4C", x"95", x"0B", x"42", x"FA", x"C3", x"4E",
+    x"08", x"2E", x"A1", x"66", x"28", x"D9", x"24", x"B2", x"76", x"5B", x"A2", x"49", x"6D", x"8B", x"D1", x"25",
+    x"72", x"F8", x"F6", x"64", x"86", x"68", x"98", x"16", x"D4", x"A4", x"5C", x"CC", x"5D", x"65", x"B6", x"92",
+    x"6C", x"70", x"48", x"50", x"FD", x"ED", x"B9", x"DA", x"5E", x"15", x"46", x"57", x"A7", x"8D", x"9D", x"84",
+    x"90", x"D8", x"AB", x"00", x"8C", x"BC", x"D3", x"0A", x"F7", x"E4", x"58", x"05", x"B8", x"B3", x"45", x"06",
+    x"D0", x"2C", x"1E", x"8F", x"CA", x"3F", x"0F", x"02", x"C1", x"AF", x"BD", x"03", x"01", x"13", x"8A", x"6B",
+    x"3A", x"91", x"11", x"41", x"4F", x"67", x"DC", x"EA", x"97", x"F2", x"CF", x"CE", x"F0", x"B4", x"E6", x"73",
+    x"96", x"AC", x"74", x"22", x"E7", x"AD", x"35", x"85", x"E2", x"F9", x"37", x"E8", x"1C", x"75", x"DF", x"6E",
+    x"47", x"F1", x"1A", x"71", x"1D", x"29", x"C5", x"89", x"6F", x"B7", x"62", x"0E", x"AA", x"18", x"BE", x"1B",
+    x"FC", x"56", x"3E", x"4B", x"C6", x"D2", x"79", x"20", x"9A", x"DB", x"C0", x"FE", x"78", x"CD", x"5A", x"F4",
+    x"1F", x"DD", x"A8", x"33", x"88", x"07", x"C7", x"31", x"B1", x"12", x"10", x"59", x"27", x"80", x"EC", x"5F",
+    x"60", x"51", x"7F", x"A9", x"19", x"B5", x"4A", x"0D", x"2D", x"E5", x"7A", x"9F", x"93", x"C9", x"9C", x"EF",
+    x"A0", x"E0", x"3B", x"4D", x"AE", x"2A", x"F5", x"B0", x"C8", x"EB", x"BB", x"3C", x"83", x"53", x"99", x"61",
+    x"17", x"2B", x"04", x"7E", x"BA", x"77", x"D6", x"26", x"E1", x"69", x"14", x"63", x"55", x"21", x"0C", x"7D"
+  );
+
+  constant RCON : rcon_array_t := (
+    1 => x"01", 2 => x"02", 3 => x"04", 4 => x"08", 5 => x"10", 6 => x"20", 7 => x"40",
+    8 => x"80", 9 => x"1B", 10 => x"36", 11 => x"6C", 12 => x"D8", 13 => x"AB", 14 => x"4D"
+  );
+
+  function xtime(b : byte_t) return byte_t is
+    variable bv  : unsigned(7 downto 0) := unsigned(b);
+    variable res : unsigned(7 downto 0);
+  begin
+    res := shift_left(bv, 1);
+    if bv(7) = '1' then
+      res := res xor to_unsigned(16#1B#, 8);
+    end if;
+    return std_logic_vector(res);
+  end function xtime;
+
+  function gmul2(b : byte_t) return byte_t is
+  begin
+    return xtime(b);
+  end function gmul2;
+
+  function gmul3(b : byte_t) return byte_t is
+    variable x : byte_t := xtime(b);
+  begin
+    return std_logic_vector(unsigned(x) xor unsigned(b));
+  end function gmul3;
+
+  function gmul9(b : byte_t) return byte_t is
+    variable x2 : byte_t := xtime(b);
+    variable x4 : byte_t := xtime(x2);
+    variable x8 : byte_t := xtime(x4);
+  begin
+    return std_logic_vector(unsigned(x8) xor unsigned(b));
+  end function gmul9;
+
+  function gmul11(b : byte_t) return byte_t is
+    variable x2 : byte_t := xtime(b);
+    variable x4 : byte_t := xtime(x2);
+    variable x8 : byte_t := xtime(x4);
+  begin
+    -- 11 = 8 + 2 + 1
+    return std_logic_vector(unsigned(x8) xor unsigned(x2) xor unsigned(b));
+  end function gmul11;
+
+  function gmul13(b : byte_t) return byte_t is
+    variable x2 : byte_t := xtime(b);
+    variable x4 : byte_t := xtime(x2);
+    variable x8 : byte_t := xtime(x4);
+  begin
+    -- 13 = 8 + 4 + 1
+    return std_logic_vector(unsigned(x8) xor unsigned(x4) xor unsigned(b));
+  end function gmul13;
+
+  function gmul14(b : byte_t) return byte_t is
+    variable x2 : byte_t := xtime(b);
+    variable x4 : byte_t := xtime(x2);
+    variable x8 : byte_t := xtime(x4);
+  begin
+    -- 14 = 8 + 4 + 2
+    return std_logic_vector(unsigned(x8) xor unsigned(x4) xor unsigned(x2));
+  end function gmul14;
+
+  function sub_byte(b : byte_t) return byte_t is
+  begin
+    return SBOX(to_integer(unsigned(b)));
+  end function sub_byte;
+
+  function inv_sub_byte(b : byte_t) return byte_t is
+  begin
+    return INV_SBOX(to_integer(unsigned(b)));
+  end function inv_sub_byte;
+
+  function sub_word(w : word_t) return word_t is
+    variable r : word_t;
+  begin
+    r(31 downto 24) := sub_byte(w(31 downto 24));
+    r(23 downto 16) := sub_byte(w(23 downto 16));
+    r(15 downto 8)  := sub_byte(w(15 downto 8));
+    r(7 downto 0)   := sub_byte(w(7 downto 0));
+    return r;
+  end function sub_word;
+
+  function rot_word(w : word_t) return word_t is
+  begin
+    return w(23 downto 0) & w(31 downto 24);
+  end function rot_word;
+
+end package body aes_pkg;
+

--- a/src/aes_round_dec.vhd
+++ b/src/aes_round_dec.vhd
@@ -1,0 +1,45 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity aes_round_dec is
+  generic (
+    IS_FINAL : boolean := false
+  );
+  port (
+    state_in  : in  std_logic_vector(127 downto 0);
+    round_key : in  std_logic_vector(127 downto 0);
+    state_out : out std_logic_vector(127 downto 0)
+  );
+end entity aes_round_dec;
+
+architecture rtl of aes_round_dec is
+  component inv_shiftrows is
+    port ( state_in : in std_logic_vector(127 downto 0); state_out : out std_logic_vector(127 downto 0) );
+  end component;
+  component inv_subbytes is
+    port ( state_in : in std_logic_vector(127 downto 0); state_out : out std_logic_vector(127 downto 0) );
+  end component;
+  component inv_mixcolumns is
+    port ( state_in : in std_logic_vector(127 downto 0); state_out : out std_logic_vector(127 downto 0) );
+  end component;
+  component add_round_key is
+    port ( state_in : in std_logic_vector(127 downto 0); round_key : in std_logic_vector(127 downto 0); state_out : out std_logic_vector(127 downto 0) );
+  end component;
+
+  signal s_isr, s_isb, s_ark, s_out : std_logic_vector(127 downto 0);
+begin
+  -- Decryption round: InvShiftRows -> InvSubBytes -> AddRoundKey -> InvMixColumns (except final: no InvMix)
+  u_isr: inv_shiftrows port map(state_in => state_in, state_out => s_isr);
+  u_isb: inv_subbytes port map(state_in => s_isr, state_out => s_isb);
+  u_ark: add_round_key port map(state_in => s_isb, round_key => round_key, state_out => s_ark);
+
+  gen_non_final: if not IS_FINAL generate
+    u_imc: inv_mixcolumns port map(state_in => s_ark, state_out => s_out);
+    state_out <= s_out;
+  end generate;
+
+  gen_final: if IS_FINAL generate
+    state_out <= s_ark;
+  end generate;
+end architecture rtl;
+

--- a/src/aes_round_enc.vhd
+++ b/src/aes_round_enc.vhd
@@ -1,0 +1,45 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity aes_round_enc is
+  generic (
+    IS_FINAL : boolean := false
+  );
+  port (
+    state_in  : in  std_logic_vector(127 downto 0);
+    round_key : in  std_logic_vector(127 downto 0);
+    state_out : out std_logic_vector(127 downto 0)
+  );
+end entity aes_round_enc;
+
+architecture rtl of aes_round_enc is
+  component subbytes is
+    port ( state_in : in std_logic_vector(127 downto 0); state_out : out std_logic_vector(127 downto 0) );
+  end component;
+  component shiftrows is
+    port ( state_in : in std_logic_vector(127 downto 0); state_out : out std_logic_vector(127 downto 0) );
+  end component;
+  component mixcolumns is
+    port ( state_in : in std_logic_vector(127 downto 0); state_out : out std_logic_vector(127 downto 0) );
+  end component;
+  component add_round_key is
+    port ( state_in : in std_logic_vector(127 downto 0); round_key : in std_logic_vector(127 downto 0); state_out : out std_logic_vector(127 downto 0) );
+  end component;
+
+  signal s1, s2, s3, s4 : std_logic_vector(127 downto 0);
+begin
+  u_sb: subbytes port map(state_in => state_in, state_out => s1);
+  u_sr: shiftrows port map(state_in => s1, state_out => s2);
+
+  gen_non_final: if not IS_FINAL generate
+    u_mc: mixcolumns port map(state_in => s2, state_out => s3);
+    u_ark: add_round_key port map(state_in => s3, round_key => round_key, state_out => s4);
+    state_out <= s4;
+  end generate;
+
+  gen_final: if IS_FINAL generate
+    u_ark_f: add_round_key port map(state_in => s2, round_key => round_key, state_out => s4);
+    state_out <= s4;
+  end generate;
+end architecture rtl;
+

--- a/src/inv_mixcolumns.vhd
+++ b/src/inv_mixcolumns.vhd
@@ -1,0 +1,43 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+use work.aes_pkg.all;
+
+entity inv_mixcolumns is
+  port (
+    state_in  : in  std_logic_vector(127 downto 0);
+    state_out : out std_logic_vector(127 downto 0)
+  );
+end entity inv_mixcolumns;
+
+architecture rtl of inv_mixcolumns is
+  function mix_col_inv(a0, a1, a2, a3 : byte_t) return std_logic_vector is
+    variable r0, r1, r2, r3 : byte_t;
+    variable r : std_logic_vector(31 downto 0);
+  begin
+    r0 := std_logic_vector(unsigned(gmul14(a0)) xor unsigned(gmul11(a1)) xor unsigned(gmul13(a2)) xor unsigned(gmul9(a3)));
+    r1 := std_logic_vector(unsigned(gmul9(a0))  xor unsigned(gmul14(a1)) xor unsigned(gmul11(a2)) xor unsigned(gmul13(a3)));
+    r2 := std_logic_vector(unsigned(gmul13(a0)) xor unsigned(gmul9(a1))  xor unsigned(gmul14(a2)) xor unsigned(gmul11(a3)));
+    r3 := std_logic_vector(unsigned(gmul11(a0)) xor unsigned(gmul13(a1)) xor unsigned(gmul9(a2))  xor unsigned(gmul14(a3)));
+    r := r0 & r1 & r2 & r3;
+    return r;
+  end function;
+
+  signal s : std_logic_vector(127 downto 0);
+  signal o : std_logic_vector(127 downto 0);
+begin
+  s <= state_in;
+
+  -- Column 0
+  o(127 downto 96) <= mix_col_inv(s(127 downto 120), s(95 downto 88), s(63 downto 56), s(31 downto 24));
+  -- Column 1
+  o(95 downto 64)  <= mix_col_inv(s(119 downto 112), s(87 downto 80), s(55 downto 48), s(23 downto 16));
+  -- Column 2
+  o(63 downto 32)  <= mix_col_inv(s(111 downto 104), s(79 downto 72), s(47 downto 40), s(15 downto 8));
+  -- Column 3
+  o(31 downto 0)   <= mix_col_inv(s(103 downto 96), s(71 downto 64), s(39 downto 32), s(7 downto 0));
+
+  state_out <= o;
+end architecture rtl;
+

--- a/src/inv_shiftrows.vhd
+++ b/src/inv_shiftrows.vhd
@@ -1,0 +1,40 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity inv_shiftrows is
+  port (
+    state_in  : in  std_logic_vector(127 downto 0);
+    state_out : out std_logic_vector(127 downto 0)
+  );
+end entity inv_shiftrows;
+
+architecture rtl of inv_shiftrows is
+  signal s : std_logic_vector(127 downto 0);
+begin
+  -- Row 0: no shift
+  s(127 downto 120) <= state_in(127 downto 120);
+  s(95 downto 88)   <= state_in(95 downto 88);
+  s(63 downto 56)   <= state_in(63 downto 56);
+  s(31 downto 24)   <= state_in(31 downto 24);
+
+  -- Row 1: right shift by 1
+  s(119 downto 112) <= state_in(23 downto 16);
+  s(87 downto 80)   <= state_in(119 downto 112);
+  s(55 downto 48)   <= state_in(87 downto 80);
+  s(23 downto 16)   <= state_in(55 downto 48);
+
+  -- Row 2: right shift by 2
+  s(111 downto 104) <= state_in(47 downto 40);
+  s(79 downto 72)   <= state_in(15 downto 8);
+  s(47 downto 40)   <= state_in(111 downto 104);
+  s(15 downto 8)    <= state_in(79 downto 72);
+
+  -- Row 3: right shift by 3 (left by 1)
+  s(103 downto 96)  <= state_in(71 downto 64);
+  s(71 downto 64)   <= state_in(39 downto 32);
+  s(39 downto 32)   <= state_in(7 downto 0);
+  s(7 downto 0)     <= state_in(103 downto 96);
+
+  state_out <= s;
+end architecture rtl;
+

--- a/src/inv_subbytes.vhd
+++ b/src/inv_subbytes.vhd
@@ -1,0 +1,33 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+use work.aes_pkg.all;
+
+entity inv_subbytes is
+  port (
+    state_in  : in  std_logic_vector(127 downto 0);
+    state_out : out std_logic_vector(127 downto 0)
+  );
+end entity inv_subbytes;
+
+architecture rtl of inv_subbytes is
+begin
+  state_out(127 downto 120) <= inv_sub_byte(state_in(127 downto 120));
+  state_out(119 downto 112) <= inv_sub_byte(state_in(119 downto 112));
+  state_out(111 downto 104) <= inv_sub_byte(state_in(111 downto 104));
+  state_out(103 downto 96)  <= inv_sub_byte(state_in(103 downto 96));
+  state_out(95 downto 88)   <= inv_sub_byte(state_in(95 downto 88));
+  state_out(87 downto 80)   <= inv_sub_byte(state_in(87 downto 80));
+  state_out(79 downto 72)   <= inv_sub_byte(state_in(79 downto 72));
+  state_out(71 downto 64)   <= inv_sub_byte(state_in(71 downto 64));
+  state_out(63 downto 56)   <= inv_sub_byte(state_in(63 downto 56));
+  state_out(55 downto 48)   <= inv_sub_byte(state_in(55 downto 48));
+  state_out(47 downto 40)   <= inv_sub_byte(state_in(47 downto 40));
+  state_out(39 downto 32)   <= inv_sub_byte(state_in(39 downto 32));
+  state_out(31 downto 24)   <= inv_sub_byte(state_in(31 downto 24));
+  state_out(23 downto 16)   <= inv_sub_byte(state_in(23 downto 16));
+  state_out(15 downto 8)    <= inv_sub_byte(state_in(15 downto 8));
+  state_out(7 downto 0)     <= inv_sub_byte(state_in(7 downto 0));
+end architecture rtl;
+

--- a/src/key_expand_aes256.vhd
+++ b/src/key_expand_aes256.vhd
@@ -1,0 +1,64 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+use work.aes_pkg.all;
+
+-- Combinational AES-256 key expansion. Generates 15 round keys (0..14), 128-bit each.
+entity key_expand_aes256 is
+  port (
+    key_in          : in  std_logic_vector(255 downto 0);
+    round_keys_flat : out std_logic_vector((15*128)-1 downto 0)
+  );
+end entity key_expand_aes256;
+
+architecture rtl of key_expand_aes256 is
+  subtype word_t is std_logic_vector(31 downto 0);
+  type words60_t is array (0 to 59) of word_t;
+
+  function rcon_word(idx : integer) return word_t is
+    variable w : word_t := (others => '0');
+  begin
+    if idx >= 1 and idx <= 14 then
+      w(31 downto 24) := RCON(idx);
+    end if;
+    return w;
+  end function;
+
+  function expand256(k : std_logic_vector(255 downto 0)) return std_logic_vector is
+    variable w : words60_t;
+    variable out_flat : std_logic_vector((15*128)-1 downto 0);
+    variable temp : word_t;
+  begin
+    -- Initial 8 words from 256-bit key (w0..w7)
+    w(0) := k(255 downto 224);
+    w(1) := k(223 downto 192);
+    w(2) := k(191 downto 160);
+    w(3) := k(159 downto 128);
+    w(4) := k(127 downto 96);
+    w(5) := k(95 downto 64);
+    w(6) := k(63 downto 32);
+    w(7) := k(31 downto 0);
+
+    for i in 8 to 59 loop
+      temp := w(i-1);
+      if (i mod 8) = 0 then
+        temp := sub_word(rot_word(temp)) xor rcon_word(i/8);
+      elsif (i mod 8) = 4 then
+        temp := sub_word(temp);
+      end if;
+      w(i) := std_logic_vector(unsigned(w(i-8)) xor unsigned(temp));
+    end loop;
+
+    -- Pack into 15 round keys, each 4 words
+    for r in 0 to 14 loop
+      out_flat(((15-1-r)*128)+127 downto ((15-1-r)*128)) := w(4*r) & w(4*r+1) & w(4*r+2) & w(4*r+3);
+    end loop;
+
+    return out_flat;
+  end function;
+
+begin
+  round_keys_flat <= expand256(key_in);
+end architecture rtl;
+

--- a/src/mixcolumns.vhd
+++ b/src/mixcolumns.vhd
@@ -1,0 +1,58 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+use work.aes_pkg.all;
+
+entity mixcolumns is
+  port (
+    state_in  : in  std_logic_vector(127 downto 0);
+    state_out : out std_logic_vector(127 downto 0)
+  );
+end entity mixcolumns;
+
+architecture rtl of mixcolumns is
+  function mix_col(a0, a1, a2, a3 : byte_t) return std_logic_vector is
+    variable r0, r1, r2, r3 : byte_t;
+    variable r : std_logic_vector(31 downto 0);
+  begin
+    r0 := std_logic_vector(unsigned(gmul2(a0)) xor unsigned(gmul3(a1)) xor unsigned(a2) xor unsigned(a3));
+    r1 := std_logic_vector(unsigned(a0) xor unsigned(gmul2(a1)) xor unsigned(gmul3(a2)) xor unsigned(a3));
+    r2 := std_logic_vector(unsigned(a0) xor unsigned(a1) xor unsigned(gmul2(a2)) xor unsigned(gmul3(a3)));
+    r3 := std_logic_vector(unsigned(gmul3(a0)) xor unsigned(a1) xor unsigned(a2) xor unsigned(gmul2(a3)));
+    r := r0 & r1 & r2 & r3;
+    return r;
+  end function;
+
+  function get_byte(v : std_logic_vector(127 downto 0); byte_index : integer) return byte_t is
+    variable hi : integer := 127 - (byte_index*8);
+    variable lo : integer := hi - 7;
+  begin
+    return v(hi downto lo);
+  end function;
+
+  function set_bytes(b0,b1,b2,b3 : byte_t) return std_logic_vector is
+  begin
+    return b0 & b1 & b2 & b3;
+  end function;
+
+  signal s : std_logic_vector(127 downto 0);
+  signal o : std_logic_vector(127 downto 0);
+begin
+  s <= state_in;
+
+  -- Column 0 (bytes 0,4,8,12 in state when arranged column-major)
+  o(127 downto 96) <= mix_col(s(127 downto 120), s(95 downto 88), s(63 downto 56), s(31 downto 24));
+
+  -- Column 1
+  o(95 downto 64)  <= mix_col(s(119 downto 112), s(87 downto 80), s(55 downto 48), s(23 downto 16));
+
+  -- Column 2
+  o(63 downto 32)  <= mix_col(s(111 downto 104), s(79 downto 72), s(47 downto 40), s(15 downto 8));
+
+  -- Column 3
+  o(31 downto 0)   <= mix_col(s(103 downto 96), s(71 downto 64), s(39 downto 32), s(7 downto 0));
+
+  state_out <= o;
+end architecture rtl;
+

--- a/src/shiftrows.vhd
+++ b/src/shiftrows.vhd
@@ -1,0 +1,49 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity shiftrows is
+  port (
+    state_in  : in  std_logic_vector(127 downto 0);
+    state_out : out std_logic_vector(127 downto 0)
+  );
+end entity shiftrows;
+
+architecture rtl of shiftrows is
+  -- State is arranged as 4x4 bytes column-major per AES spec.
+  -- Bytes: s[r,c] where r=row(0..3), c=col(0..3)
+  -- Mapping helper function to slice bits for s[r,c]
+  function idx(r : integer; c : integer) return integer is
+  begin
+    -- byte index (0..15) in column-major: b = 4*c + r; msb first
+    return 15 - (4*c + r);
+  end function;
+
+  signal s : std_logic_vector(127 downto 0);
+begin
+  -- Row 0: no shift
+  s(127 downto 120) <= state_in(127 downto 120); -- s[0,0]
+  s(95 downto 88)   <= state_in(95 downto 88);   -- s[0,1]
+  s(63 downto 56)   <= state_in(63 downto 56);   -- s[0,2]
+  s(31 downto 24)   <= state_in(31 downto 24);   -- s[0,3]
+
+  -- Row 1: left shift by 1
+  s(119 downto 112) <= state_in(87 downto 80);   -- s[1,1] <= s[1,0]
+  s(87 downto 80)   <= state_in(55 downto 48);   -- s[1,2] <= s[1,1]
+  s(55 downto 48)   <= state_in(23 downto 16);   -- s[1,3] <= s[1,2]
+  s(23 downto 16)   <= state_in(119 downto 112); -- s[1,0] <= s[1,3]
+
+  -- Row 2: left shift by 2
+  s(111 downto 104) <= state_in(47 downto 40);   -- s[2,2] <= s[2,0]
+  s(79 downto 72)   <= state_in(15 downto 8);    -- s[2,3] <= s[2,1]
+  s(47 downto 40)   <= state_in(111 downto 104); -- s[2,0] <= s[2,2]
+  s(15 downto 8)    <= state_in(79 downto 72);   -- s[2,1] <= s[2,3]
+
+  -- Row 3: left shift by 3 (right by 1)
+  s(103 downto 96)  <= state_in(7 downto 0);     -- s[3,3] <= s[3,0]
+  s(71 downto 64)   <= state_in(103 downto 96);  -- s[3,0] <= s[3,1]
+  s(39 downto 32)   <= state_in(71 downto 64);   -- s[3,1] <= s[3,2]
+  s(7 downto 0)     <= state_in(39 downto 32);   -- s[3,2] <= s[3,3]
+
+  state_out <= s;
+end architecture rtl;
+

--- a/src/subbytes.vhd
+++ b/src/subbytes.vhd
@@ -1,0 +1,34 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+use work.aes_pkg.all;
+
+entity subbytes is
+  port (
+    state_in  : in  std_logic_vector(127 downto 0);
+    state_out : out std_logic_vector(127 downto 0)
+  );
+end entity subbytes;
+
+architecture rtl of subbytes is
+begin
+  -- Byte-wise S-Box substitution, state byte order preserved
+  state_out(127 downto 120) <= sub_byte(state_in(127 downto 120));
+  state_out(119 downto 112) <= sub_byte(state_in(119 downto 112));
+  state_out(111 downto 104) <= sub_byte(state_in(111 downto 104));
+  state_out(103 downto 96)  <= sub_byte(state_in(103 downto 96));
+  state_out(95 downto 88)   <= sub_byte(state_in(95 downto 88));
+  state_out(87 downto 80)   <= sub_byte(state_in(87 downto 80));
+  state_out(79 downto 72)   <= sub_byte(state_in(79 downto 72));
+  state_out(71 downto 64)   <= sub_byte(state_in(71 downto 64));
+  state_out(63 downto 56)   <= sub_byte(state_in(63 downto 56));
+  state_out(55 downto 48)   <= sub_byte(state_in(55 downto 48));
+  state_out(47 downto 40)   <= sub_byte(state_in(47 downto 40));
+  state_out(39 downto 32)   <= sub_byte(state_in(39 downto 32));
+  state_out(31 downto 24)   <= sub_byte(state_in(31 downto 24));
+  state_out(23 downto 16)   <= sub_byte(state_in(23 downto 16));
+  state_out(15 downto 8)    <= sub_byte(state_in(15 downto 8));
+  state_out(7 downto 0)     <= sub_byte(state_in(7 downto 0));
+end architecture rtl;
+

--- a/tb/tb_aes256_core.vhd
+++ b/tb/tb_aes256_core.vhd
@@ -1,0 +1,87 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity tb_aes256_core is
+end entity;
+
+architecture sim of tb_aes256_core is
+  component aes256_core is
+    port (
+      clk      : in  std_logic;
+      rst      : in  std_logic;
+      start    : in  std_logic;
+      enc_n    : in  std_logic;
+      key      : in  std_logic_vector(255 downto 0);
+      data_in  : in  std_logic_vector(127 downto 0);
+      data_out : out std_logic_vector(127 downto 0);
+      ready    : out std_logic
+    );
+  end component;
+
+  signal clk      : std_logic := '0';
+  signal rst      : std_logic := '1';
+  signal start    : std_logic := '0';
+  signal enc_n    : std_logic := '1';
+  signal key      : std_logic_vector(255 downto 0);
+  signal data_in  : std_logic_vector(127 downto 0);
+  signal data_out : std_logic_vector(127 downto 0);
+  signal ready    : std_logic;
+
+  constant CLK_PERIOD : time := 10 ns;
+
+  -- NIST AES-256 Known Answer Test (SP 800-38A F.5.5 CBC, first block ECB)
+  constant K256 : std_logic_vector(255 downto 0) := x"603deb1015ca71be2b73aef0857d7781" & x"1f352c073b6108d72d9810a30914dff4";
+  constant P    : std_logic_vector(127 downto 0) := x"6bc1bee22e409f96e93d7e117393172a";
+  constant C    : std_logic_vector(127 downto 0) := x"f3eed1bdb5d2a03c064b5a7e3db181f8";
+
+begin
+  -- clock
+  clk <= not clk after CLK_PERIOD/2;
+
+  -- DUT
+  dut: aes256_core
+    port map (
+      clk => clk,
+      rst => rst,
+      start => start,
+      enc_n => enc_n,
+      key => key,
+      data_in => data_in,
+      data_out => data_out,
+      ready => ready
+    );
+
+  -- Stimulus
+  process
+  begin
+    key <= K256;
+    data_in <= P;
+    wait for 5*CLK_PERIOD;
+    rst <= '0';
+    wait for 2*CLK_PERIOD;
+
+    -- Encrypt
+    enc_n <= '1';
+    start <= '1';
+    wait for CLK_PERIOD;
+    start <= '0';
+    -- Wait until ready
+    wait until ready = '1';
+    assert data_out = C report "AES-256 encrypt mismatch" severity failure;
+
+    -- Decrypt
+    data_in <= C;
+    enc_n <= '0';
+    start <= '1';
+    wait for CLK_PERIOD;
+    start <= '0';
+    wait until ready = '1';
+    assert data_out = P report "AES-256 decrypt mismatch" severity failure;
+
+    report "All tests passed" severity note;
+    wait;
+  end process;
+
+end architecture sim;
+


### PR DESCRIPTION
Implement a complete AES-256 VHDL core with encryption, decryption, key expansion, and a NIST-vector testbench for Xilinx ISE 14.7 compatibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-0e22ad58-af1f-4164-b34f-ed1b5a80b337"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0e22ad58-af1f-4164-b34f-ed1b5a80b337"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

