### PR TITLE
Vhdl aes 256 core implementation and testbench

### DIFF
--- a/aes_vhdl/src/aes_addroundkey.vhd
+++ b/aes_vhdl/src/aes_addroundkey.vhd
@@ -1,0 +1,16 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity aes_addroundkey is
+  port (
+    state_i : in  std_logic_vector(127 downto 0);
+    rkey_i  : in  std_logic_vector(127 downto 0);
+    state_o : out std_logic_vector(127 downto 0)
+  );
+end entity aes_addroundkey;
+
+architecture rtl of aes_addroundkey is
+begin
+  state_o <= state_i xor rkey_i;
+end architecture rtl;
+

--- a/aes_vhdl/src/aes_dec_round.vhd
+++ b/aes_vhdl/src/aes_dec_round.vhd
@@ -1,0 +1,21 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use work.aes_pkg.all;
+
+entity aes_dec_round is
+  port (
+    state_i      : in  std_logic_vector(127 downto 0);
+    rkey_i       : in  std_logic_vector(127 downto 0);
+    last_round_i : in  std_logic;
+    state_o      : out std_logic_vector(127 downto 0)
+  );
+end entity aes_dec_round;
+
+architecture rtl of aes_dec_round is
+  signal s1, s2 : std_logic_vector(127 downto 0);
+begin
+  s1 <= inv_shift_rows(inv_sub_bytes_128(state_i));
+  s2 <= s1 xor rkey_i;
+  state_o <= s2 when last_round_i = '1' else inv_mix_columns(s2);
+end architecture rtl;
+

--- a/aes_vhdl/src/aes_decrypt_core.vhd
+++ b/aes_vhdl/src/aes_decrypt_core.vhd
@@ -1,0 +1,111 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity aes_decrypt_core is
+  port (
+    clk_i      : in  std_logic;
+    rst_i      : in  std_logic;
+    start_i    : in  std_logic;
+    key_i      : in  std_logic_vector(255 downto 0);
+    block_i    : in  std_logic_vector(127 downto 0);
+    ready_o    : out std_logic;
+    valid_o    : out std_logic;
+    block_o    : out std_logic_vector(127 downto 0)
+  );
+end entity aes_decrypt_core;
+
+architecture rtl of aes_decrypt_core is
+  component aes_key_schedule_256 is
+    port (
+      key_i    : in  std_logic_vector(255 downto 0);
+      round_i  : in  std_logic_vector(3 downto 0);
+      rkey_o   : out std_logic_vector(127 downto 0)
+    );
+  end component;
+
+  component aes_dec_round is
+    port (
+      state_i      : in  std_logic_vector(127 downto 0);
+      rkey_i       : in  std_logic_vector(127 downto 0);
+      last_round_i : in  std_logic;
+      state_o      : out std_logic_vector(127 downto 0)
+    );
+  end component;
+
+  type fsm_t is (IDLE, INIT_ADD, ROUND);
+  signal fsm_s       : fsm_t;
+  signal round_cnt   : unsigned(3 downto 0); -- 14 down to 1, 0 used in INIT_ADD
+  signal rkey_idx_s  : std_logic_vector(3 downto 0);
+  signal state_reg   : std_logic_vector(127 downto 0);
+  signal round_out_s : std_logic_vector(127 downto 0);
+  signal rkey_s      : std_logic_vector(127 downto 0);
+  signal last_round  : std_logic;
+  signal ready_s     : std_logic;
+
+begin
+
+  key_sched_i : aes_key_schedule_256
+    port map (
+      key_i   => key_i,
+      round_i => rkey_idx_s,
+      rkey_o  => rkey_s
+    );
+
+  round_i : aes_dec_round
+    port map (
+      state_i      => state_reg,
+      rkey_i       => rkey_s,
+      last_round_i => last_round,
+      state_o      => round_out_s
+    );
+
+  process(clk_i)
+  begin
+    if rising_edge(clk_i) then
+      if rst_i = '1' then
+        round_cnt <= (others => '0');
+        state_reg <= (others => '0');
+        fsm_s     <= IDLE;
+        ready_s   <= '1';
+        valid_o   <= '0';
+      else
+        valid_o <= '0';
+        case fsm_s is
+          when IDLE =>
+            ready_s <= '1';
+            if start_i = '1' then
+              state_reg <= block_i;
+              round_cnt <= to_unsigned(14, 4);
+              fsm_s     <= INIT_ADD;
+              ready_s   <= '0';
+            end if;
+
+          when INIT_ADD =>
+            -- Initial AddRoundKey with last round key rkey[14]
+            state_reg <= state_reg xor rkey_s;
+            round_cnt <= to_unsigned(13, 4);
+            fsm_s     <= ROUND;
+
+          when ROUND =>
+            state_reg <= round_out_s;
+            if round_cnt = to_unsigned(0, 4) then
+              valid_o <= '1';
+              fsm_s   <= IDLE;
+            else
+              round_cnt <= round_cnt - 1;
+            end if;
+        end case;
+      end if;
+    end if;
+  end process;
+
+  -- key index selection (counts down)
+  rkey_idx_s <= std_logic_vector(round_cnt) when (fsm_s = ROUND) else std_logic_vector(round_cnt);
+  last_round <= '1' when (fsm_s = ROUND and round_cnt = to_unsigned(0, 4)) else '0';
+
+  block_o <= state_reg when valid_o = '1' else round_out_s;
+  ready_o <= ready_s;
+
+end architecture rtl;
+

--- a/aes_vhdl/src/aes_enc_round.vhd
+++ b/aes_vhdl/src/aes_enc_round.vhd
@@ -1,0 +1,22 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use work.aes_pkg.all;
+
+entity aes_enc_round is
+  port (
+    state_i      : in  std_logic_vector(127 downto 0);
+    rkey_i       : in  std_logic_vector(127 downto 0);
+    last_round_i : in  std_logic;
+    state_o      : out std_logic_vector(127 downto 0)
+  );
+end entity aes_enc_round;
+
+architecture rtl of aes_enc_round is
+  signal s1, s2, s3 : std_logic_vector(127 downto 0);
+begin
+  s1 <= sub_bytes_128(state_i);
+  s2 <= shift_rows(s1);
+  s3 <= mix_columns(s2);
+  state_o <= (s2 xor rkey_i) when last_round_i = '1' else (s3 xor rkey_i);
+end architecture rtl;
+

--- a/aes_vhdl/src/aes_encrypt_core.vhd
+++ b/aes_vhdl/src/aes_encrypt_core.vhd
@@ -1,0 +1,115 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity aes_encrypt_core is
+  port (
+    clk_i      : in  std_logic;
+    rst_i      : in  std_logic;
+    start_i    : in  std_logic;
+    key_i      : in  std_logic_vector(255 downto 0);
+    block_i    : in  std_logic_vector(127 downto 0);
+    ready_o    : out std_logic;
+    valid_o    : out std_logic;
+    block_o    : out std_logic_vector(127 downto 0)
+  );
+end entity aes_encrypt_core;
+
+architecture rtl of aes_encrypt_core is
+  component aes_key_schedule_256 is
+    port (
+      key_i    : in  std_logic_vector(255 downto 0);
+      round_i  : in  std_logic_vector(3 downto 0);
+      rkey_o   : out std_logic_vector(127 downto 0)
+    );
+  end component;
+
+  component aes_enc_round is
+    port (
+      state_i      : in  std_logic_vector(127 downto 0);
+      rkey_i       : in  std_logic_vector(127 downto 0);
+      last_round_i : in  std_logic;
+      state_o      : out std_logic_vector(127 downto 0)
+    );
+  end component;
+
+  type fsm_t is (IDLE, INIT_ADD, ROUND);
+  signal fsm_s       : fsm_t;
+  signal round_cnt   : unsigned(3 downto 0); -- 0..14, where 0 used in INIT_ADD
+  signal rkey_idx_s  : std_logic_vector(3 downto 0);
+  signal state_reg   : std_logic_vector(127 downto 0);
+  signal round_out_s : std_logic_vector(127 downto 0);
+  signal rkey_s      : std_logic_vector(127 downto 0);
+  signal last_round  : std_logic;
+  signal ready_s     : std_logic;
+
+begin
+
+  key_sched_i : aes_key_schedule_256
+    port map (
+      key_i   => key_i,
+      round_i => rkey_idx_s,
+      rkey_o  => rkey_s
+    );
+
+  round_i : aes_enc_round
+    port map (
+      state_i      => state_reg,
+      rkey_i       => rkey_s,
+      last_round_i => last_round,
+      state_o      => round_out_s
+    );
+
+  process(clk_i)
+  begin
+    if rising_edge(clk_i) then
+      if rst_i = '1' then
+        round_cnt <= (others => '0');
+        state_reg <= (others => '0');
+        fsm_s     <= IDLE;
+        ready_s   <= '1';
+        valid_o   <= '0';
+      else
+        valid_o <= '0';
+        case fsm_s is
+          when IDLE =>
+            ready_s <= '1';
+            if start_i = '1' then
+              -- Prepare initial AddRoundKey with round key 0
+              state_reg <= block_i;
+              round_cnt <= to_unsigned(0, 4);
+              fsm_s     <= INIT_ADD;
+              ready_s   <= '0';
+            end if;
+
+          when INIT_ADD =>
+            -- Perform initial AddRoundKey: state := state xor rkey[0]
+            state_reg <= state_reg xor rkey_s;
+            round_cnt <= to_unsigned(1, 4);
+            fsm_s     <= ROUND;
+
+          when ROUND =>
+            -- Apply round with rkey[round_cnt]
+            state_reg <= round_out_s;
+            if round_cnt = to_unsigned(14, 4) then
+              -- finished final round this cycle
+              valid_o <= '1';
+              fsm_s   <= IDLE;
+            else
+              round_cnt <= round_cnt + 1;
+            end if;
+        end case;
+      end if;
+    end if;
+  end process;
+
+  -- key index selection
+  rkey_idx_s <= std_logic_vector(round_cnt) when (fsm_s = ROUND) else x"0";
+  last_round <= '1' when (fsm_s = ROUND and round_cnt = to_unsigned(14, 4)) else '0';
+
+  -- Drive output block when valid; otherwise undefined/previous
+  block_o <= state_reg when valid_o = '1' else round_out_s;
+  ready_o <= ready_s;
+
+end architecture rtl;
+

--- a/aes_vhdl/src/aes_inv_mixcolumns.vhd
+++ b/aes_vhdl/src/aes_inv_mixcolumns.vhd
@@ -1,0 +1,16 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use work.aes_pkg.all;
+
+entity aes_inv_mixcolumns is
+  port (
+    state_i : in  std_logic_vector(127 downto 0);
+    state_o : out std_logic_vector(127 downto 0)
+  );
+end entity aes_inv_mixcolumns;
+
+architecture rtl of aes_inv_mixcolumns is
+begin
+  state_o <= inv_mix_columns(state_i);
+end architecture rtl;
+

--- a/aes_vhdl/src/aes_inv_shiftrows.vhd
+++ b/aes_vhdl/src/aes_inv_shiftrows.vhd
@@ -1,0 +1,16 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use work.aes_pkg.all;
+
+entity aes_inv_shiftrows is
+  port (
+    state_i : in  std_logic_vector(127 downto 0);
+    state_o : out std_logic_vector(127 downto 0)
+  );
+end entity aes_inv_shiftrows;
+
+architecture rtl of aes_inv_shiftrows is
+begin
+  state_o <= inv_shift_rows(state_i);
+end architecture rtl;
+

--- a/aes_vhdl/src/aes_inv_subbytes.vhd
+++ b/aes_vhdl/src/aes_inv_subbytes.vhd
@@ -1,0 +1,16 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use work.aes_pkg.all;
+
+entity aes_inv_subbytes is
+  port (
+    state_i : in  std_logic_vector(127 downto 0);
+    state_o : out std_logic_vector(127 downto 0)
+  );
+end entity aes_inv_subbytes;
+
+architecture rtl of aes_inv_subbytes is
+begin
+  state_o <= inv_sub_bytes_128(state_i);
+end architecture rtl;
+

--- a/aes_vhdl/src/aes_key_schedule_256.vhd
+++ b/aes_vhdl/src/aes_key_schedule_256.vhd
@@ -1,0 +1,32 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+use work.aes_pkg.all;
+
+entity aes_key_schedule_256 is
+  port (
+    key_i    : in  std_logic_vector(255 downto 0);
+    round_i  : in  std_logic_vector(3 downto 0); -- 0..14
+    rkey_o   : out std_logic_vector(127 downto 0)
+  );
+end entity aes_key_schedule_256;
+
+architecture rtl of aes_key_schedule_256 is
+  signal words_s      : word_array_60_t;
+  signal roundkeys_s  : roundkey_array_t;
+begin
+  words_s     <= expand_key_256(key_i);
+  roundkeys_s <= build_roundkeys(words_s);
+
+  process(roundkeys_s, round_i)
+    variable idx : integer;
+  begin
+    idx := to_integer(unsigned(round_i));
+    if idx >= 0 and idx <= 14 then
+      rkey_o <= roundkeys_s(idx);
+    else
+      rkey_o <= (others => '0');
+    end if;
+  end process;
+end architecture rtl;
+

--- a/aes_vhdl/src/aes_mixcolumns.vhd
+++ b/aes_vhdl/src/aes_mixcolumns.vhd
@@ -1,0 +1,16 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use work.aes_pkg.all;
+
+entity aes_mixcolumns is
+  port (
+    state_i : in  std_logic_vector(127 downto 0);
+    state_o : out std_logic_vector(127 downto 0)
+  );
+end entity aes_mixcolumns;
+
+architecture rtl of aes_mixcolumns is
+begin
+  state_o <= mix_columns(state_i);
+end architecture rtl;
+

--- a/aes_vhdl/src/aes_pkg.vhd
+++ b/aes_vhdl/src/aes_pkg.vhd
@@ -1,0 +1,329 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+package aes_pkg is
+
+  subtype byte_t is std_logic_vector(7 downto 0);
+  subtype word_t is std_logic_vector(31 downto 0);
+
+  type byte_array16_t is array (0 to 15) of byte_t;
+  type word_array_60_t is array (0 to 59) of word_t;
+  type roundkey_array_t is array (0 to 14) of std_logic_vector(127 downto 0);
+
+  -- AES S-Box and inverse S-Box
+  type sbox_t is array (0 to 255) of byte_t;
+
+  constant AES_SBOX : sbox_t := (
+    x"63", x"7C", x"77", x"7B", x"F2", x"6B", x"6F", x"C5", x"30", x"01", x"67", x"2B", x"FE", x"D7", x"AB", x"76",
+    x"CA", x"82", x"C9", x"7D", x"FA", x"59", x"47", x"F0", x"AD", x"D4", x"A2", x"AF", x"9C", x"A4", x"72", x"C0",
+    x"B7", x"FD", x"93", x"26", x"36", x"3F", x"F7", x"CC", x"34", x"A5", x"E5", x"F1", x"71", x"D8", x"31", x"15",
+    x"04", x"C7", x"23", x"C3", x"18", x"96", x"05", x"9A", x"07", x"12", x"80", x"E2", x"EB", x"27", x"B2", x"75",
+    x"09", x"83", x"2C", x"1A", x"1B", x"6E", x"5A", x"A0", x"52", x"3B", x"D6", x"B3", x"29", x"E3", x"2F", x"84",
+    x"53", x"D1", x"00", x"ED", x"20", x"FC", x"B1", x"5B", x"6A", x"CB", x"BE", x"39", x"4A", x"4C", x"58", x"CF",
+    x"D0", x"EF", x"AA", x"FB", x"43", x"4D", x"33", x"85", x"45", x"F9", x"02", x"7F", x"50", x"3C", x"9F", x"A8",
+    x"51", x"A3", x"40", x"8F", x"92", x"9D", x"38", x"F5", x"BC", x"B6", x"DA", x"21", x"10", x"FF", x"F3", x"D2",
+    x"CD", x"0C", x"13", x"EC", x"5F", x"97", x"44", x"17", x"C4", x"A7", x"7E", x"3D", x"64", x"5D", x"19", x"73",
+    x"60", x"81", x"4F", x"DC", x"22", x"2A", x"90", x"88", x"46", x"EE", x"B8", x"14", x"DE", x"5E", x"0B", x"DB",
+    x"E0", x"32", x"3A", x"0A", x"49", x"06", x"24", x"5C", x"C2", x"D3", x"AC", x"62", x"91", x"95", x"E4", x"79",
+    x"E7", x"C8", x"37", x"6D", x"8D", x"D5", x"4E", x"A9", x"6C", x"56", x"F4", x"EA", x"65", x"7A", x"AE", x"08",
+    x"BA", x"78", x"25", x"2E", x"1C", x"A6", x"B4", x"C6", x"E8", x"DD", x"74", x"1F", x"4B", x"BD", x"8B", x"8A",
+    x"70", x"3E", x"B5", x"66", x"48", x"03", x"F6", x"0E", x"61", x"35", x"57", x"B9", x"86", x"C1", x"1D", x"9E",
+    x"E1", x"F8", x"98", x"11", x"69", x"D9", x"8E", x"94", x"9B", x"1E", x"87", x"E9", x"CE", x"55", x"28", x"DF",
+    x"8C", x"A1", x"89", x"0D", x"BF", x"E6", x"42", x"68", x"41", x"99", x"2D", x"0F", x"B0", x"54", x"BB", x"16"
+  );
+
+  constant AES_INV_SBOX : sbox_t := (
+    x"52", x"09", x"6A", x"D5", x"30", x"36", x"A5", x"38", x"BF", x"40", x"A3", x"9E", x"81", x"F3", x"D7", x"FB",
+    x"7C", x"E3", x"39", x"82", x"9B", x"2F", x"FF", x"87", x"34", x"8E", x"43", x"44", x"C4", x"DE", x"E9", x"CB",
+    x"54", x"7B", x"94", x"32", x"A6", x"C2", x"23", x"3D", x"EE", x"4C", x"95", x"0B", x"42", x"FA", x"C3", x"4E",
+    x"08", x"2E", x"A1", x"66", x"28", x"D9", x"24", x"B2", x"76", x"5B", x"A2", x"49", x"6D", x"8B", x"D1", x"25",
+    x"72", x"F8", x"F6", x"64", x"86", x"68", x"98", x"16", x"D4", x"A4", x"5C", x"CC", x"5D", x"65", x"B6", x"92",
+    x"6C", x"70", x"48", x"50", x"FD", x"ED", x"B9", x"DA", x"5E", x"15", x"46", x"57", x"A7", x"8D", x"9D", x"84",
+    x"90", x"D8", x"AB", x"00", x"8C", x"BC", x"D3", x"0A", x"F7", x"E4", x"58", x"05", x"B8", x"B3", x"45", x"06",
+    x"D0", x"2C", x"1E", x"8F", x"CA", x"3F", x"0F", x"02", x"C1", x"AF", x"BD", x"03", x"01", x"13", x"8A", x"6B",
+    x"3A", x"91", x"11", x"41", x"4F", x"67", x"DC", x"EA", x"97", x"F2", x"CF", x"CE", x"F0", x"B4", x"E6", x"73",
+    x"96", x"AC", x"74", x"22", x"E7", x"AD", x"35", x"85", x"E2", x"F9", x"37", x"E8", x"1C", x"75", x"DF", x"6E",
+    x"47", x"F1", x"1A", x"71", x"1D", x"29", x"C5", x"89", x"6F", x"B7", x"62", x"0E", x"AA", x"18", x"BE", x"1B",
+    x"FC", x"56", x"3E", x"4B", x"C6", x"D2", x"79", x"20", x"9A", x"DB", x"C0", x"FE", x"78", x"CD", x"5A", x"F4",
+    x"1F", x"DD", x"A8", x"33", x"88", x"07", x"C7", x"31", x"B1", x"12", x"10", x"59", x"27", x"80", x"EC", x"5F",
+    x"60", x"51", x"7F", x"A9", x"19", x"B5", x"4A", x"0D", x"2D", x"E5", x"7A", x"9F", x"93", x"C9", x"9C", x"EF",
+    x"A0", x"E0", x"3B", x"4D", x"AE", x"2A", x"F5", x"B0", x"C8", x"EB", x"BB", x"3C", x"83", x"53", x"99", x"61",
+    x"17", x"2B", x"04", x"7E", x"BA", x"77", x"D6", x"26", x"E1", x"69", x"14", x"63", x"55", x"21", x"0C", x"7D"
+  );
+
+  -- Round constants Rcon[i] for i=1..14 (only first 7 used for AES-256)
+  type rcon_array_t is array (1 to 14) of word_t;
+  constant AES_RCON : rcon_array_t := (
+    1 => x"01000000", 2 => x"02000000", 3 => x"04000000", 4 => x"08000000",
+    5 => x"10000000", 6 => x"20000000", 7 => x"40000000", 8 => x"80000000",
+    9 => x"1B000000", 10 => x"36000000", 11 => x"6C000000", 12 => x"D8000000",
+    13 => x"AB000000", 14 => x"4D000000"
+  );
+
+  -- GF(2^8) helpers
+  function xtime(b : byte_t) return byte_t;
+  function gf_mul(a : byte_t; b : byte_t) return byte_t;
+
+  -- Byte substitution helpers
+  function sub_byte(b : byte_t) return byte_t;
+  function inv_sub_byte(b : byte_t) return byte_t;
+
+  -- Word helpers for key schedule
+  function rot_word(w : word_t) return word_t;
+  function sub_word(w : word_t) return word_t;
+
+  -- State helpers
+  function sub_bytes_128(state_in : std_logic_vector(127 downto 0)) return std_logic_vector;
+  function inv_sub_bytes_128(state_in : std_logic_vector(127 downto 0)) return std_logic_vector;
+  function shift_rows(state_in : std_logic_vector(127 downto 0)) return std_logic_vector;
+  function inv_shift_rows(state_in : std_logic_vector(127 downto 0)) return std_logic_vector;
+  function mix_columns(state_in : std_logic_vector(127 downto 0)) return std_logic_vector;
+  function inv_mix_columns(state_in : std_logic_vector(127 downto 0)) return std_logic_vector;
+
+  -- Key expansion (AES-256)
+  function expand_key_256(key_in : std_logic_vector(255 downto 0)) return word_array_60_t;
+  function build_roundkeys(words : word_array_60_t) return roundkey_array_t;
+
+end package aes_pkg;
+
+package body aes_pkg is
+
+  function xtime(b : byte_t) return byte_t is
+    variable result : byte_t;
+  begin
+    result := std_logic_vector(shift_left(unsigned(b), 1));
+    if b(7) = '1' then
+      result := result xor x"1B";
+    end if;
+    return result;
+  end function;
+
+  function gf_mul(a : byte_t; b : byte_t) return byte_t is
+    variable res  : byte_t := (others => '0');
+    variable temp : byte_t := a;
+    variable bv   : unsigned(7 downto 0) := unsigned(b);
+  begin
+    for i in 0 to 7 loop
+      if bv(i) = '1' then
+        res := res xor temp;
+      end if;
+      temp := xtime(temp);
+    end loop;
+    return res;
+  end function;
+
+  function sub_byte(b : byte_t) return byte_t is
+  begin
+    return AES_SBOX(to_integer(unsigned(b)));
+  end function;
+
+  function inv_sub_byte(b : byte_t) return byte_t is
+  begin
+    return AES_INV_SBOX(to_integer(unsigned(b)));
+  end function;
+
+  function rot_word(w : word_t) return word_t is
+  begin
+    return w(23 downto 0) & w(31 downto 24);
+  end function;
+
+  function sub_word(w : word_t) return word_t is
+    variable b0, b1, b2, b3 : byte_t;
+  begin
+    b3 := sub_byte(w(31 downto 24));
+    b2 := sub_byte(w(23 downto 16));
+    b1 := sub_byte(w(15 downto 8));
+    b0 := sub_byte(w(7 downto 0));
+    return b3 & b2 & b1 & b0;
+  end function;
+
+  function sub_bytes_128(state_in : std_logic_vector(127 downto 0)) return std_logic_vector is
+    variable out_state : std_logic_vector(127 downto 0);
+    variable hi, lo    : integer;
+    variable b         : byte_t;
+  begin
+    for i in 0 to 15 loop
+      hi := 127 - 8*i;
+      lo := hi - 7;
+      b := state_in(hi downto lo);
+      out_state(hi downto lo) := sub_byte(b);
+    end loop;
+    return out_state;
+  end function;
+
+  function inv_sub_bytes_128(state_in : std_logic_vector(127 downto 0)) return std_logic_vector is
+    variable out_state : std_logic_vector(127 downto 0);
+    variable hi, lo    : integer;
+    variable b         : byte_t;
+  begin
+    for i in 0 to 15 loop
+      hi := 127 - 8*i;
+      lo := hi - 7;
+      b := state_in(hi downto lo);
+      out_state(hi downto lo) := inv_sub_byte(b);
+    end loop;
+    return out_state;
+  end function;
+
+  function shift_rows(state_in : std_logic_vector(127 downto 0)) return std_logic_vector is
+    variable in_b  : byte_array16_t;
+    variable out_b : byte_array16_t := (others => (others => '0'));
+    variable hi, lo : integer;
+    variable res    : std_logic_vector(127 downto 0) := (others => '0');
+    variable src_idx : integer;
+  begin
+    -- unpack
+    for i in 0 to 15 loop
+      hi := 127 - 8*i;
+      lo := hi - 7;
+      in_b(i) := state_in(hi downto lo);
+    end loop;
+    -- shift rows (left by row index)
+    for r in 0 to 3 loop
+      for c in 0 to 3 loop
+        src_idx := 4*((c + r) mod 4) + r;
+        out_b(4*c + r) := in_b(src_idx);
+      end loop;
+    end loop;
+    -- pack
+    for i in 0 to 15 loop
+      hi := 127 - 8*i;
+      lo := hi - 7;
+      res(hi downto lo) := out_b(i);
+    end loop;
+    return res;
+  end function;
+
+  function inv_shift_rows(state_in : std_logic_vector(127 downto 0)) return std_logic_vector is
+    variable in_b  : byte_array16_t;
+    variable out_b : byte_array16_t := (others => (others => '0'));
+    variable hi, lo : integer;
+    variable res    : std_logic_vector(127 downto 0) := (others => '0');
+    variable src_idx : integer;
+  begin
+    -- unpack
+    for i in 0 to 15 loop
+      hi := 127 - 8*i;
+      lo := hi - 7;
+      in_b(i) := state_in(hi downto lo);
+    end loop;
+    -- inverse shift rows (right by row index)
+    for r in 0 to 3 loop
+      for c in 0 to 3 loop
+        src_idx := 4*((c - r + 4) mod 4) + r;
+        out_b(4*c + r) := in_b(src_idx);
+      end loop;
+    end loop;
+    -- pack
+    for i in 0 to 15 loop
+      hi := 127 - 8*i;
+      lo := hi - 7;
+      res(hi downto lo) := out_b(i);
+    end loop;
+    return res;
+  end function;
+
+  function mix_columns(state_in : std_logic_vector(127 downto 0)) return std_logic_vector is
+    variable in_b  : byte_array16_t;
+    variable out_b : byte_array16_t := (others => (others => '0'));
+    variable hi, lo : integer;
+    variable res    : std_logic_vector(127 downto 0) := (others => '0');
+    variable a0, a1, a2, a3 : byte_t;
+  begin
+    -- unpack
+    for i in 0 to 15 loop
+      hi := 127 - 8*i;
+      lo := hi - 7;
+      in_b(i) := state_in(hi downto lo);
+    end loop;
+    -- per column
+    for c in 0 to 3 loop
+      a0 := in_b(4*c + 0);
+      a1 := in_b(4*c + 1);
+      a2 := in_b(4*c + 2);
+      a3 := in_b(4*c + 3);
+      out_b(4*c + 0) := gf_mul(a0, x"02") xor gf_mul(a1, x"03") xor a2 xor a3;
+      out_b(4*c + 1) := a0 xor gf_mul(a1, x"02") xor gf_mul(a2, x"03") xor a3;
+      out_b(4*c + 2) := a0 xor a1 xor gf_mul(a2, x"02") xor gf_mul(a3, x"03");
+      out_b(4*c + 3) := gf_mul(a0, x"03") xor a1 xor a2 xor gf_mul(a3, x"02");
+    end loop;
+    -- pack
+    for i in 0 to 15 loop
+      hi := 127 - 8*i;
+      lo := hi - 7;
+      res(hi downto lo) := out_b(i);
+    end loop;
+    return res;
+  end function;
+
+  function inv_mix_columns(state_in : std_logic_vector(127 downto 0)) return std_logic_vector is
+    variable in_b  : byte_array16_t;
+    variable out_b : byte_array16_t := (others => (others => '0'));
+    variable hi, lo : integer;
+    variable res    : std_logic_vector(127 downto 0) := (others => '0');
+    variable a0, a1, a2, a3 : byte_t;
+  begin
+    -- unpack
+    for i in 0 to 15 loop
+      hi := 127 - 8*i;
+      lo := hi - 7;
+      in_b(i) := state_in(hi downto lo);
+    end loop;
+    -- per column
+    for c in 0 to 3 loop
+      a0 := in_b(4*c + 0);
+      a1 := in_b(4*c + 1);
+      a2 := in_b(4*c + 2);
+      a3 := in_b(4*c + 3);
+      out_b(4*c + 0) := gf_mul(a0, x"0E") xor gf_mul(a1, x"0B") xor gf_mul(a2, x"0D") xor gf_mul(a3, x"09");
+      out_b(4*c + 1) := gf_mul(a0, x"09") xor gf_mul(a1, x"0E") xor gf_mul(a2, x"0B") xor gf_mul(a3, x"0D");
+      out_b(4*c + 2) := gf_mul(a0, x"0D") xor gf_mul(a1, x"09") xor gf_mul(a2, x"0E") xor gf_mul(a3, x"0B");
+      out_b(4*c + 3) := gf_mul(a0, x"0B") xor gf_mul(a1, x"0D") xor gf_mul(a2, x"09") xor gf_mul(a3, x"0E");
+    end loop;
+    -- pack
+    for i in 0 to 15 loop
+      hi := 127 - 8*i;
+      lo := hi - 7;
+      res(hi downto lo) := out_b(i);
+    end loop;
+    return res;
+  end function;
+
+  function expand_key_256(key_in : std_logic_vector(255 downto 0)) return word_array_60_t is
+    variable w : word_array_60_t;
+    variable temp : word_t;
+    variable i : integer;
+  begin
+    -- initial 8 words from key_in (MSB first)
+    for k in 0 to 7 loop
+      w(k) := key_in(255 - 32*k downto 224 - 32*k);
+    end loop;
+    i := 8;
+    while i < 60 loop
+      temp := w(i - 1);
+      if (i mod 8) = 0 then
+        temp := sub_word(rot_word(temp)) xor AES_RCON(i/8);
+      elsif (i mod 8) = 4 then
+        temp := sub_word(temp);
+      end if;
+      w(i) := std_logic_vector(unsigned(w(i - 8)) xor unsigned(temp));
+      i := i + 1;
+    end loop;
+    return w;
+  end function;
+
+  function build_roundkeys(words : word_array_60_t) return roundkey_array_t is
+    variable rk : roundkey_array_t;
+    variable base : integer;
+  begin
+    for r in 0 to 14 loop
+      base := 4*r;
+      rk(r) := words(base)(31 downto 0) & words(base+1)(31 downto 0) & words(base+2)(31 downto 0) & words(base+3)(31 downto 0);
+      -- Note: words(base) is already big-endian word; concatenation forms 128-bit round key
+    end loop;
+    return rk;
+  end function;
+
+end package body aes_pkg;
+

--- a/aes_vhdl/src/aes_shiftrows.vhd
+++ b/aes_vhdl/src/aes_shiftrows.vhd
@@ -1,0 +1,16 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use work.aes_pkg.all;
+
+entity aes_shiftrows is
+  port (
+    state_i : in  std_logic_vector(127 downto 0);
+    state_o : out std_logic_vector(127 downto 0)
+  );
+end entity aes_shiftrows;
+
+architecture rtl of aes_shiftrows is
+begin
+  state_o <= shift_rows(state_i);
+end architecture rtl;
+

--- a/aes_vhdl/src/aes_subbytes.vhd
+++ b/aes_vhdl/src/aes_subbytes.vhd
@@ -1,0 +1,16 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use work.aes_pkg.all;
+
+entity aes_subbytes is
+  port (
+    state_i : in  std_logic_vector(127 downto 0);
+    state_o : out std_logic_vector(127 downto 0)
+  );
+end entity aes_subbytes;
+
+architecture rtl of aes_subbytes is
+begin
+  state_o <= sub_bytes_128(state_i);
+end architecture rtl;
+

--- a/aes_vhdl/src/aes_top.vhd
+++ b/aes_vhdl/src/aes_top.vhd
@@ -1,0 +1,80 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity aes_top is
+  port (
+    clk_i      : in  std_logic;
+    rst_i      : in  std_logic;
+    start_i    : in  std_logic;
+    enc_i      : in  std_logic; -- '1' encrypt, '0' decrypt
+    key_i      : in  std_logic_vector(255 downto 0);
+    block_i    : in  std_logic_vector(127 downto 0);
+    ready_o    : out std_logic;
+    valid_o    : out std_logic;
+    block_o    : out std_logic_vector(127 downto 0)
+  );
+end entity aes_top;
+
+architecture rtl of aes_top is
+  component aes_encrypt_core is
+    port (
+      clk_i   : in  std_logic;
+      rst_i   : in  std_logic;
+      start_i : in  std_logic;
+      key_i   : in  std_logic_vector(255 downto 0);
+      block_i : in  std_logic_vector(127 downto 0);
+      ready_o : out std_logic;
+      valid_o : out std_logic;
+      block_o : out std_logic_vector(127 downto 0)
+    );
+  end component;
+
+  component aes_decrypt_core is
+    port (
+      clk_i   : in  std_logic;
+      rst_i   : in  std_logic;
+      start_i : in  std_logic;
+      key_i   : in  std_logic_vector(255 downto 0);
+      block_i : in  std_logic_vector(127 downto 0);
+      ready_o : out std_logic;
+      valid_o : out std_logic;
+      block_o : out std_logic_vector(127 downto 0)
+    );
+  end component;
+
+  signal ready_enc, ready_dec : std_logic;
+  signal valid_enc, valid_dec : std_logic;
+  signal block_enc, block_dec : std_logic_vector(127 downto 0);
+
+begin
+
+  u_enc : aes_encrypt_core
+    port map (
+      clk_i   => clk_i,
+      rst_i   => rst_i,
+      start_i => start_i and enc_i,
+      key_i   => key_i,
+      block_i => block_i,
+      ready_o => ready_enc,
+      valid_o => valid_enc,
+      block_o => block_enc
+    );
+
+  u_dec : aes_decrypt_core
+    port map (
+      clk_i   => clk_i,
+      rst_i   => rst_i,
+      start_i => start_i and not enc_i,
+      key_i   => key_i,
+      block_i => block_i,
+      ready_o => ready_dec,
+      valid_o => valid_dec,
+      block_o => block_dec
+    );
+
+  ready_o <= ready_enc when enc_i = '1' else ready_dec;
+  valid_o <= valid_enc when enc_i = '1' else valid_dec;
+  block_o <= block_enc when enc_i = '1' else block_dec;
+
+end architecture rtl;
+

--- a/aes_vhdl/tb/tb_aes_decrypt.vhd
+++ b/aes_vhdl/tb/tb_aes_decrypt.vhd
@@ -1,0 +1,78 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity tb_aes_decrypt is
+end entity;
+
+architecture sim of tb_aes_decrypt is
+  component aes_top is
+    port (
+      clk_i      : in  std_logic;
+      rst_i      : in  std_logic;
+      start_i    : in  std_logic;
+      enc_i      : in  std_logic;
+      key_i      : in  std_logic_vector(255 downto 0);
+      block_i    : in  std_logic_vector(127 downto 0);
+      ready_o    : out std_logic;
+      valid_o    : out std_logic;
+      block_o    : out std_logic_vector(127 downto 0)
+    );
+  end component;
+
+  signal clk   : std_logic := '0';
+  signal rst   : std_logic := '1';
+  signal start : std_logic := '0';
+  signal enc   : std_logic := '0';
+  signal key   : std_logic_vector(255 downto 0);
+  signal din   : std_logic_vector(127 downto 0);
+  signal ready : std_logic;
+  signal valid : std_logic;
+  signal dout  : std_logic_vector(127 downto 0);
+
+  constant C_KEY  : std_logic_vector(255 downto 0) := x"000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
+  constant C_PTXT : std_logic_vector(127 downto 0) := x"00112233445566778899aabbccddeeff";
+  constant C_CTXT : std_logic_vector(127 downto 0) := x"8ea2b7ca516745bfeafc49904b496089";
+
+begin
+  -- clock
+  clk <= not clk after 5 ns;
+
+  uut : aes_top
+    port map (
+      clk_i   => clk,
+      rst_i   => rst,
+      start_i => start,
+      enc_i   => enc,
+      key_i   => key,
+      block_i => din,
+      ready_o => ready,
+      valid_o => valid,
+      block_o => dout
+    );
+
+  stim : process
+  begin
+    key <= C_KEY;
+    din <= C_CTXT;
+    wait for 20 ns;
+    rst <= '0';
+    wait for 20 ns;
+    wait until rising_edge(clk);
+    if ready = '1' then
+      start <= '1';
+    end if;
+    wait until rising_edge(clk);
+    start <= '0';
+
+    -- wait for result
+    wait until valid = '1';
+    assert dout = C_PTXT report "AES-256 DEC mismatch" severity error;
+    report "AES-256 DEC OK" severity note;
+
+    wait for 50 ns;
+    assert false report "SIM DONE" severity failure;
+  end process;
+
+end architecture sim;
+

--- a/aes_vhdl/tb/tb_aes_encrypt.vhd
+++ b/aes_vhdl/tb/tb_aes_encrypt.vhd
@@ -1,0 +1,78 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity tb_aes_encrypt is
+end entity;
+
+architecture sim of tb_aes_encrypt is
+  component aes_top is
+    port (
+      clk_i      : in  std_logic;
+      rst_i      : in  std_logic;
+      start_i    : in  std_logic;
+      enc_i      : in  std_logic;
+      key_i      : in  std_logic_vector(255 downto 0);
+      block_i    : in  std_logic_vector(127 downto 0);
+      ready_o    : out std_logic;
+      valid_o    : out std_logic;
+      block_o    : out std_logic_vector(127 downto 0)
+    );
+  end component;
+
+  signal clk   : std_logic := '0';
+  signal rst   : std_logic := '1';
+  signal start : std_logic := '0';
+  signal enc   : std_logic := '1';
+  signal key   : std_logic_vector(255 downto 0);
+  signal din   : std_logic_vector(127 downto 0);
+  signal ready : std_logic;
+  signal valid : std_logic;
+  signal dout  : std_logic_vector(127 downto 0);
+
+  constant C_KEY  : std_logic_vector(255 downto 0) := x"000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
+  constant C_PTXT : std_logic_vector(127 downto 0) := x"00112233445566778899aabbccddeeff";
+  constant C_CTXT : std_logic_vector(127 downto 0) := x"8ea2b7ca516745bfeafc49904b496089";
+
+begin
+  -- clock
+  clk <= not clk after 5 ns;
+
+  uut : aes_top
+    port map (
+      clk_i   => clk,
+      rst_i   => rst,
+      start_i => start,
+      enc_i   => enc,
+      key_i   => key,
+      block_i => din,
+      ready_o => ready,
+      valid_o => valid,
+      block_o => dout
+    );
+
+  stim : process
+  begin
+    key <= C_KEY;
+    din <= C_PTXT;
+    wait for 20 ns;
+    rst <= '0';
+    wait for 20 ns;
+    wait until rising_edge(clk);
+    if ready = '1' then
+      start <= '1';
+    end if;
+    wait until rising_edge(clk);
+    start <= '0';
+
+    -- wait for result
+    wait until valid = '1';
+    assert dout = C_CTXT report "AES-256 ENC mismatch" severity error;
+    report "AES-256 ENC OK" severity note;
+
+    wait for 50 ns;
+    assert false report "SIM DONE" severity failure;
+  end process;
+
+end architecture sim;
+


### PR DESCRIPTION
Implement a complete AES-256 encryption/decryption core in VHDL, including key schedule, iterative rounds, and testbenches using NIST known-answer vectors.

---
<a href="https://cursor.com/background-agent?bcId=bc-57f70a57-c25f-4725-804c-c79501296306"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-57f70a57-c25f-4725-804c-c79501296306"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

